### PR TITLE
Conditionalize enabling of RBAC

### DIFF
--- a/examples/classic/kubernetes.classic.rbac.json
+++ b/examples/classic/kubernetes.classic.rbac.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "enableRbac": true
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+        "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agent",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "servicePrincipalClientID": "",
+      "servicePrincipalClientSecret": ""
+    }
+  }
+}

--- a/parts/kubernetesmaster-kube-addon-manager.yaml
+++ b/parts/kubernetesmaster-kube-addon-manager.yaml
@@ -1,26 +1,3 @@
-#apiVersion: v1
-#kind: ServiceAccount
-#metadata:
-#  labels:
-#    k8s-app: kube-addon-manager
-#  name: kube-addon-manager
-#  namespace: kube-system
-#---
-#apiVersion: rbac.authorization.k8s.io/v1beta1
-#kind: ClusterRoleBinding
-#metadata:
-#  name: kube-addon-manager
-#  labels:
-#    k8s-app: kube-addon-manager
-#roleRef:
-#  apiGroup: rbac.authorization.k8s.io
-#  kind: ClusterRole
-#  name: cluster-admin
-#subjects:
-#- kind: ServiceAccount
-#  name: kube-addon-manager
-#  namespace: kube-system
----
 apiVersion: v1
 kind: Pod
 metadata:
@@ -39,7 +16,6 @@ spec:
     - name: addons
       mountPath: "/etc/kubernetes/addons"
       readOnly: true
-  serviceAccountName: kube-addon-manager
   volumes:
   - name: addons
     hostPath:

--- a/parts/kubernetesmaster-kube-addon-manager.yaml
+++ b/parts/kubernetesmaster-kube-addon-manager.yaml
@@ -1,9 +1,31 @@
+#apiVersion: v1
+#kind: ServiceAccount
+#metadata:
+#  labels:
+#    k8s-app: kube-addon-manager
+#  name: kube-addon-manager
+#  namespace: kube-system
+#---
+#apiVersion: rbac.authorization.k8s.io/v1beta1
+#kind: ClusterRoleBinding
+#metadata:
+#  name: kube-addon-manager
+#  labels:
+#    k8s-app: kube-addon-manager
+#roleRef:
+#  apiGroup: rbac.authorization.k8s.io
+#  kind: ClusterRole
+#  name: cluster-admin
+#subjects:
+#- kind: ServiceAccount
+#  name: kube-addon-manager
+#  namespace: kube-system
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: kube-addon-manager
   namespace: kube-system
-  version: v1
 spec:
   hostNetwork: true
   containers:
@@ -17,6 +39,7 @@ spec:
     - name: addons
       mountPath: "/etc/kubernetes/addons"
       readOnly: true
+  serviceAccountName: kube-addon-manager
   volumes:
   - name: addons
     hostPath:

--- a/parts/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/kubernetesmaster-kube-apiserver.yaml
@@ -31,7 +31,7 @@ spec:
         - "--service-account-key-file=/etc/kubernetes/certs/apiserver.key"
         - "--storage-backend=etcd2"
         - "--v=4"
-        - "--authorization-mode=RBAC"
+        - "<kubernetesEnableRbac>"
       volumeMounts:
         - name: "etc-kubernetes"
           mountPath: "/etc/kubernetes"

--- a/parts/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/kubernetesmaster-kube-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
         - "--root-ca-file=/etc/kubernetes/certs/ca.crt"
         - "--service-account-private-key-file=/etc/kubernetes/certs/apiserver.key"
         - "--leader-elect=true"
-        - "--use-service-account-credentials"
+        - "<kubernetesEnableRbac>"
         - "--v=2"
       volumeMounts: 
         - name: "etc-kubernetes"

--- a/parts/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/kubernetesmasteraddons-heapster-deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-
 ---
-
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: system:heapster
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -21,12 +22,30 @@ subjects:
 - kind: ServiceAccount
   name: heapster
   namespace: kube-system
-
 ---
 kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    k8s-app: heapster
+    version: v1.4.0
+    kubernetes.io/cluster-service: "true"
+  namespace: kube-system
+  name: heapster-v1.4.0
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
+      version: v1.4.0
   template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: heapster
+        version: v1.4.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""    
     spec:
       tolerations:
       - key: "CriticalAddonsOnly"
@@ -74,22 +93,3 @@ spec:
           name: MY_POD_NAMESPACE
       nodeSelector:
         beta.kubernetes.io/os: linux
-    metadata:
-      labels:
-        task: monitoring
-        k8s-app: heapster
-        version: v1.4.0
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
-  selector:
-    matchLabels:
-      k8s-app: heapster
-      version: v1.4.0
-apiVersion: extensions/v1beta1
-metadata:
-  labels:
-    k8s-app: heapster
-    version: v1.4.0
-    kubernetes.io/cluster-service: "true"
-  namespace: kube-system
-  name: heapster-v1.4.0

--- a/parts/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -1,8 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
@@ -30,5 +58,6 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+      serviceAccountName: kubernetes-dashboard
       nodeSelector:
         beta.kubernetes.io/os: linux 

--- a/parts/kubernetesmasteraddons-kubernetes-dashboard-service.yaml
+++ b/parts/kubernetesmasteraddons-kubernetes-dashboard-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -244,6 +244,15 @@ write_files:
     sed -i "s|<kubernetesHeapsterSpec>|{{WrapAsVariable "kubernetesHeapsterSpec"}}|g; s|<kubernetesAddonResizerSpec>|{{WrapAsVariable "kubernetesAddonResizerSpec"}}|g" "/etc/kubernetes/addons/kube-heapster-deployment.yaml"
     sed -i "s|<kubernetesDashboardSpec>|{{WrapAsVariable "kubernetesDashboardSpec"}}|g" "/etc/kubernetes/addons/kubernetes-dashboard-deployment.yaml"
 
+{{if .OrchestratorProfile.KubernetesConfig.EnableRbac }}
+    # If RBAC enabled then add parameters to API server and Controller manager configuration
+    sed -i "s|<kubernetesEnableRbac>|--authorization-mode=RBAC|g" "/etc/kubernetes/manifests/kube-apiserver.yaml"
+    sed -i "s|<kubernetesEnableRbac>|--use-service-account-credentials|g" "/etc/kubernetes/manifests/kube-controller-manager.yaml"
+{{else}}
+    sed -i "/<kubernetesEnableRbac>/d" "/etc/kubernetes/manifests/kube-apiserver.yaml"
+    sed -i "/<kubernetesEnableRbac>/d" "/etc/kubernetes/manifests/kube-controller-manager.yaml"
+{{end}}
+
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}
     # If Calico Policy enabled then update Cluster Cidr
     sed -i "s|<kubeClusterCidr>|{{WrapAsVariable "kubeClusterCidr"}}|g" "/etc/kubernetes/addons/calico-daemonset.yaml"

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -61,7 +61,7 @@ var KubeImages = map[api.OrchestratorVersion]map[string]string{
 		"addonresizer": "addon-resizer:1.7",
 		"heapster":     "heapster:v1.3.0",
 		"dns":          "k8s-dns-kube-dns-amd64:1.14.2",
-		"addonmanager": "kube-addon-manager-amd64:v6.4",
+		"addonmanager": "kube-addon-manager-amd64:v6.4-beta.2",
 		"dnsmasq":      "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":        "pause-amd64:3.0",
 		"windowszip":   "v1.6.6intwinnat.zip",

--- a/pkg/acsengine/pki.go
+++ b/pkg/acsengine/pki.go
@@ -70,7 +70,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 		var err error
 		organization := make([]string, 1)
 		organization[0] = "system:masters"
-		clientCertificate, clientPrivateKey, err = createCertificate("client", caCertificate, caPrivateKey, false, nil, nil)
+		clientCertificate, clientPrivateKey, err = createCertificate("client", caCertificate, caPrivateKey, false, nil, nil, organization)
 		errors <- err
 	}()
 
@@ -78,7 +78,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 		var err error
 		organization := make([]string, 1)
 		organization[0] = "system:masters"
-		kubeConfigCertificate, kubeConfigPrivateKey, err = createCertificate("client", caCertificate, caPrivateKey, false, nil, nil)
+		kubeConfigCertificate, kubeConfigPrivateKey, err = createCertificate("client", caCertificate, caPrivateKey, false, nil, nil, organization)
 		errors <- err
 	}()
 

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -549,6 +549,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.ClusterSubnet = api.ClusterSubnet
 	vlabs.NetworkPolicy = api.NetworkPolicy
 	vlabs.DockerBridgeSubnet = api.DockerBridgeSubnet
+	vlabs.EnableRbac = api.EnableRbac
 }
 
 func convertMasterProfileToV20160930(api *MasterProfile, v20160930 *v20160930.MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -572,6 +572,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.ClusterSubnet = vlabs.ClusterSubnet
 	api.NetworkPolicy = vlabs.NetworkPolicy
 	api.DockerBridgeSubnet = vlabs.DockerBridgeSubnet
+	api.EnableRbac = vlabs.EnableRbac
 }
 
 func convertV20160930MasterProfile(v20160930 *v20160930.MasterProfile, api *MasterProfile) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -130,6 +130,7 @@ type KubernetesConfig struct {
 	ClusterSubnet       string `json:"clusterSubnet,omitempty"`
 	NetworkPolicy       string `json:"networkPolicy,omitempty"`
 	DockerBridgeSubnet  string `json:"dockerBridgeSubnet,omitempty"`
+	EnableRbac          bool   `json:"enableRbac,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -134,6 +134,7 @@ type KubernetesConfig struct {
 	ClusterSubnet       string `json:"clusterSubnet,omitempty"`
 	NetworkPolicy       string `json:"networkPolicy,omitempty"`
 	DockerBridgeSubnet  string `json:"DockerBridgeSubnet,omitempty"`
+	EnableRbac          bool   `json:"enableRbac,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster


### PR DESCRIPTION
This is follow up work to the original PR raised -- https://github.com/Azure/acs-engine/pull/918

* Add rbac cluster definition example
* Update kube addon manager to support clusterrolebinding creation
* Update kube-addon-manager to use service account
* Update API server with RBAC parameter
* Update Controller Manager to use separate accounts per controller
* Update heapster to support RBAC
* Update dashboard to support RBAC
* Add enableRbac field to ClusterConfig and add docs